### PR TITLE
Scale trees

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-DATABASE_URL="postgresql://postgres.fducbfbomteiknvfpbbc:DPW3fvq6dgw7zjm-ufa@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
-DIRECT_URL="postgresql://postgres.fducbfbomteiknvfpbbc:DPW3fvq6dgw7zjm-ufa@aws-0-us-east-1.pooler.supabase.com:5432/postgres"

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
-
+.env
 # vercel
 .vercel
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,13 @@
         "@clerk/nextjs": "^5.1.6",
         "@prisma/client": "^5.16.1",
         "dotenv": "^16.4.5",
+        "konva": "^9.3.13",
         "lucide-react": "^0.400.0",
         "next": "14.2.4",
         "prisma": "^5.16.1",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-konva": "^18.2.10"
       },
       "devDependencies": {
         "@testing-library/react": "^16.0.0",
@@ -1810,14 +1812,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1828,6 +1828,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.8",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.8.tgz",
+      "integrity": "sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2846,8 +2854,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4900,6 +4907,17 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
@@ -5057,6 +5075,25 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/konva": {
+      "version": "9.3.13",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.13.tgz",
+      "integrity": "sha512-hs0ysHnqjK9noZ/rkfDNJINfbNhkXMgjgkJ8uc6vU0amu05mSDtRlukz5kKHOaSnWHA6miXcHJydvPABh18Y8A==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ]
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -6161,6 +6198,51 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-konva": {
+      "version": "18.2.10",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-18.2.10.tgz",
+      "integrity": "sha512-ohcX1BJINL43m4ynjZ24MxFI1syjBdrXhqVxYVDw2rKgr3yuS0x/6m1Y2Z4sl4T/gKhfreBx8KHisd0XC6OT1g==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.2",
+        "its-fine": "^1.1.1",
+        "react-reconciler": "~0.29.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "@clerk/nextjs": "^5.1.6",
     "@prisma/client": "^5.16.1",
     "dotenv": "^16.4.5",
+    "konva": "^9.3.13",
     "lucide-react": "^0.400.0",
     "next": "14.2.4",
     "prisma": "^5.16.1",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-konva": "^18.2.10"
   },
   "devDependencies": {
     "@testing-library/react": "^16.0.0",

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -6,7 +6,7 @@ export type GetArtBlocksResponse = {
   artBlocks: ArtBlockDataLocal[];
   moreToFetch: boolean;
 };
-
+export const mode = "dynamic";
 export async function GET(req: NextRequest) {
   //extract the block count and id of end-of-feed from get params
   const params = req.nextUrl.searchParams;

--- a/src/app/api/userAuthCallback/route.ts
+++ b/src/app/api/userAuthCallback/route.ts
@@ -1,5 +1,6 @@
 import { userReqHandler } from "@/middleware/userReqHandler";
 import { redirect } from "next/navigation";
+export const mode = "dynamic";
 
 //this is the callback for the user to be redirected to after the user has been authenticated
 export const GET = userReqHandler(async req => {

--- a/src/components/ArtBlock/Color/ColorBlock.tsx
+++ b/src/components/ArtBlock/Color/ColorBlock.tsx
@@ -3,9 +3,10 @@ import { ColorBlockParams } from "@/services/ArtBlock.types";
 type ColorBlockProps = ColorBlockParams;
 
 export default function ColorBlock(params: ColorBlockProps) {
+  const size = 300;
   return (
     <div
-      className="h-[500px] w-[500px]"
+      className="h-[350px] w-[350px]"
       style={{ backgroundColor: params.color }}
     ></div>
   );

--- a/src/components/ArtBlock/Color/ColorBlock.tsx
+++ b/src/components/ArtBlock/Color/ColorBlock.tsx
@@ -5,7 +5,7 @@ type ColorBlockProps = ColorBlockParams;
 export default function ColorBlock(params: ColorBlockProps) {
   return (
     <div
-      className="h-[300px] w-[300px]"
+      className="h-[500px] w-[500px]"
       style={{ backgroundColor: params.color }}
     ></div>
   );

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -1,7 +1,6 @@
 import { Stage, Layer, Rect } from "react-konva";
 import { Trapezoid } from "./Trapezoid";
 import { Branch, Point } from "./generate";
-import { K } from "vitest/dist/reporters-yx5ZTtEV.js";
 
 /**
    interface TrapezoidProps {

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -34,9 +34,22 @@ const Konvas = (props: KonvasProps) => {
   const rightXPositiveSpace = width / 2 - boundaries.bottomRight.x; //for right, rightmost x=0 would mean we have half the width, subtract however far right it reaches
   const topYNegativeSpace = height - boundaries.topLeft.y; //0 height would leave {height} space, any protrusion up subtracts from that negative space
   const bottomYPositiveSpace = boundaries.bottomRight.y; //y=0 maps to bottom, so however high its lowest point isis how high above the bottom of canvas minY is
+  const treeTotalDims = {
+    width: boundaries.bottomRight.x - boundaries.topLeft.x,
+    height: boundaries.bottomRight.y - boundaries.topLeft.y
+  }; //total size of the tree bounding box
+  const xMidpoint = boundaries.topLeft.x + treeTotalDims.width / 2;
+  const canvasFitScaleFactor =
+    0.9 * Math.min(width / treeTotalDims.width, height / treeTotalDims.height); //scale factor to fit the tree in the canvas
   return (
     <Stage width={width} height={height}>
-      <Layer>
+      <Layer
+        scale={{ x: canvasFitScaleFactor, y: canvasFitScaleFactor }}
+        offset={{
+          x: -width / 2 / canvasFitScaleFactor + xMidpoint,
+          y: -height / canvasFitScaleFactor + 1.1 * bottomYPositiveSpace
+        }}
+      >
         {/* background */}
         <Rect
           x={0}
@@ -49,8 +62,8 @@ const Konvas = (props: KonvasProps) => {
         {branches.map((branch, idx) => (
           <Trapezoid
             key={`branches${idx}`}
-            x={branch.origin.x + width / 2}
-            y={branch.origin.y + height}
+            x={branch.origin.x}
+            y={branch.origin.y}
             startWidth={branch.startWidth}
             endWidth={branch.endWidth}
             length={branch.length}

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -49,6 +49,7 @@ const Konvas = (props: KonvasProps) => {
             stroke={branch.color}
             strokeWidth={0}
             rotation={180 + branch.angle}
+            roundEnds={true}
           />
         ))}
       </Layer>

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -1,6 +1,6 @@
 import { Stage, Layer, Rect } from "react-konva";
 import { Trapezoid } from "./Trapezoid";
-import { Branch } from "./generate";
+import { Branch, Point } from "./generate";
 import { K } from "vitest/dist/reporters-yx5ZTtEV.js";
 
 /**
@@ -22,9 +22,18 @@ interface KonvasProps {
   height: number;
   backgroundColor: string;
   branches: Branch[];
+  boundaries: {
+    topLeft: Point;
+    bottomRight: Point;
+  };
 }
 const Konvas = (props: KonvasProps) => {
-  const { width, height, backgroundColor, branches } = props;
+  const { width, height, backgroundColor, branches, boundaries } = props;
+
+  const leftXNegativeSpace = width / 2 + boundaries.topLeft.x; //after placing the tree in the middle of the canvas, its actual left edge is at half width plus its (negative) leftMost end
+  const rightXPositiveSpace = width / 2 - boundaries.bottomRight.x; //for right, rightmost x=0 would mean we have half the width, subtract however far right it reaches
+  const topYNegativeSpace = height - boundaries.topLeft.y; //0 height would leave {height} space, any protrusion up subtracts from that negative space
+  const bottomYPositiveSpace = boundaries.bottomRight.y; //y=0 maps to bottom, so however high its lowest point isis how high above the bottom of canvas minY is
   return (
     <Stage width={width} height={height}>
       <Layer>

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -1,4 +1,4 @@
-import { Stage, Layer } from "react-konva";
+import { Stage, Layer, Rect } from "react-konva";
 import { Trapezoid } from "./Trapezoid";
 import { Branch } from "./generate";
 import { K } from "vitest/dist/reporters-yx5ZTtEV.js";
@@ -23,27 +23,37 @@ interface KonvasProps {
   backgroundColor: string;
   branches: Branch[];
 }
-export const Konvas = (props: KonvasProps) => {
+const Konvas = (props: KonvasProps) => {
   const { width, height, backgroundColor, branches } = props;
   return (
     <Stage width={width} height={height}>
       <Layer>
+        {/* background */}
+        <Rect
+          x={0}
+          y={0}
+          width={width}
+          height={height}
+          fill={backgroundColor}
+        />
+        {/* tree branches */}
         {branches.map((branch, idx) => (
           <Trapezoid
             key={`branches${idx}`}
-            x={branch.origin.x}
-            y={branch.origin.y}
+            x={branch.origin.x + width / 2}
+            y={branch.origin.y + height}
             startWidth={branch.startWidth}
             endWidth={branch.endWidth}
             length={branch.length}
-            angle={branch.angle}
             fill={branch.color}
             stroke={branch.color}
             strokeWidth={0}
-            rotation={branch.angle}
+            rotation={180 + branch.angle}
           />
         ))}
       </Layer>
     </Stage>
   );
 };
+
+export default Konvas;

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -1,0 +1,49 @@
+import { Stage, Layer } from "react-konva";
+import { Trapezoid } from "./Trapezoid";
+import { Branch } from "./generate";
+import { K } from "vitest/dist/reporters-yx5ZTtEV.js";
+
+/**
+   interface TrapezoidProps {
+    x: number;
+    y: number;
+    startWidth: number;
+    endWidth: number;
+    length: number;
+    angle: number;
+    fill: string;
+    stroke: string;
+    strokeWidth: number;
+    rotation: number;
+  }
+  */
+interface KonvasProps {
+  width: number;
+  height: number;
+  backgroundColor: string;
+  branches: Branch[];
+}
+export const Konvas = (props: KonvasProps) => {
+  const { width, height, backgroundColor, branches } = props;
+  return (
+    <Stage width={width} height={height}>
+      <Layer>
+        {branches.map((branch, idx) => (
+          <Trapezoid
+            key={`branches${idx}`}
+            x={branch.origin.x}
+            y={branch.origin.y}
+            startWidth={branch.startWidth}
+            endWidth={branch.endWidth}
+            length={branch.length}
+            angle={branch.angle}
+            fill={branch.color}
+            stroke={branch.color}
+            strokeWidth={0}
+            rotation={branch.angle}
+          />
+        ))}
+      </Layer>
+    </Stage>
+  );
+};

--- a/src/components/ArtBlock/Tree/Trapezoid.tsx
+++ b/src/components/ArtBlock/Tree/Trapezoid.tsx
@@ -15,7 +15,7 @@ interface TrapezoidProps {
 }
 export const Trapezoid = (props: TrapezoidProps) => {
   return (
-    <div>
+    <>
       <Line
         x={props.x}
         y={props.y}
@@ -49,6 +49,6 @@ export const Trapezoid = (props: TrapezoidProps) => {
           offsetY={-props.length}
         />
       )}
-    </div>
+    </>
   );
 };

--- a/src/components/ArtBlock/Tree/Trapezoid.tsx
+++ b/src/components/ArtBlock/Tree/Trapezoid.tsx
@@ -5,11 +5,12 @@ interface TrapezoidProps {
   startWidth: number;
   endWidth: number;
   length: number;
-  angle: number;
   fill: string;
   stroke: string;
   strokeWidth: number;
   rotation: number;
+  offsetX?: number;
+  offsetY?: number;
 }
 export const Trapezoid = (props: TrapezoidProps) => {
   return (
@@ -31,6 +32,8 @@ export const Trapezoid = (props: TrapezoidProps) => {
       stroke={props.stroke}
       strokeWidth={props.strokeWidth}
       rotation={props.rotation}
+      offsetX={props.offsetX}
+      offsetY={props.offsetY}
     />
   );
 };

--- a/src/components/ArtBlock/Tree/Trapezoid.tsx
+++ b/src/components/ArtBlock/Tree/Trapezoid.tsx
@@ -1,4 +1,4 @@
-import { Line } from "react-konva";
+import { Circle, Line } from "react-konva";
 interface TrapezoidProps {
   x: number;
   y: number;
@@ -9,31 +9,46 @@ interface TrapezoidProps {
   stroke: string;
   strokeWidth: number;
   rotation: number;
+  roundEnds?: boolean;
   offsetX?: number;
   offsetY?: number;
 }
 export const Trapezoid = (props: TrapezoidProps) => {
   return (
-    <Line
-      x={props.x}
-      y={props.y}
-      points={[
-        -props.startWidth / 2,
-        0,
-        -props.endWidth / 2,
-        props.length,
-        props.endWidth / 2,
-        props.length,
-        props.startWidth / 2,
-        0
-      ]}
-      closed
-      fill={props.fill}
-      stroke={props.stroke}
-      strokeWidth={props.strokeWidth}
-      rotation={props.rotation}
-      offsetX={props.offsetX}
-      offsetY={props.offsetY}
-    />
+    <div>
+      <Line
+        x={props.x}
+        y={props.y}
+        points={[
+          -props.startWidth / 2,
+          0,
+          -props.endWidth / 2,
+          props.length,
+          props.endWidth / 2,
+          props.length,
+          props.startWidth / 2,
+          0
+        ]}
+        closed
+        fill={props.fill}
+        stroke={props.stroke}
+        strokeWidth={props.strokeWidth}
+        rotation={props.rotation}
+        offsetX={props.offsetX}
+        offsetY={props.offsetY}
+      />
+      {props.roundEnds && (
+        <Circle
+          x={props.x}
+          y={props.y}
+          radius={props.endWidth / 2}
+          fill={props.fill}
+          stroke={props.stroke}
+          strokeWidth={props.strokeWidth}
+          rotation={props.rotation}
+          offsetY={-props.length}
+        />
+      )}
+    </div>
   );
 };

--- a/src/components/ArtBlock/Tree/Trapezoid.tsx
+++ b/src/components/ArtBlock/Tree/Trapezoid.tsx
@@ -1,0 +1,36 @@
+import { Line } from "react-konva";
+interface TrapezoidProps {
+  x: number;
+  y: number;
+  startWidth: number;
+  endWidth: number;
+  length: number;
+  angle: number;
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  rotation: number;
+}
+export const Trapezoid = (props: TrapezoidProps) => {
+  return (
+    <Line
+      x={props.x}
+      y={props.y}
+      points={[
+        -props.startWidth / 2,
+        0,
+        -props.endWidth / 2,
+        props.length,
+        props.endWidth / 2,
+        props.length,
+        props.startWidth / 2,
+        0
+      ]}
+      closed
+      fill={props.fill}
+      stroke={props.stroke}
+      strokeWidth={props.strokeWidth}
+      rotation={props.rotation}
+    />
+  );
+};

--- a/src/components/ArtBlock/Tree/TreeBlock.tsx
+++ b/src/components/ArtBlock/Tree/TreeBlock.tsx
@@ -7,10 +7,14 @@ type TreeBlockProps = TreeBlockParams;
 
 const TreeBlock = (params: TreeBlockProps) => {
   const { branches, boundaries } = generateTree(params);
+  const size = 500;
   return (
     <div
-      className="h-[700px] w-[700px]"
-      style={{ backgroundColor: params.backgroundColor }}
+      style={{
+        backgroundColor: params.backgroundColor,
+        width: size,
+        height: size
+      }}
     >
       {/*debug: just display all the param values*/}
       {/* {Object.entries(params).map(([key, value]) => (
@@ -22,8 +26,8 @@ const TreeBlock = (params: TreeBlockProps) => {
       <Konvas
         branches={branches}
         boundaries={boundaries}
-        width={700}
-        height={700}
+        width={size}
+        height={size}
         backgroundColor={params.backgroundColor}
       />
     </div>

--- a/src/components/ArtBlock/Tree/TreeBlock.tsx
+++ b/src/components/ArtBlock/Tree/TreeBlock.tsx
@@ -7,7 +7,7 @@ type TreeBlockProps = TreeBlockParams;
 
 const TreeBlock = (params: TreeBlockProps) => {
   const { branches, boundaries } = generateTree(params);
-  const size = 500;
+  const size = 350;
   return (
     <div
       style={{

--- a/src/components/ArtBlock/Tree/TreeBlock.tsx
+++ b/src/components/ArtBlock/Tree/TreeBlock.tsx
@@ -1,6 +1,7 @@
 import { TreeBlockParams } from "@/services/ArtBlock.types";
 import { useEffect } from "react";
 import generateTree from "./generate";
+import Konvas from "./Konvas";
 
 type TreeBlockProps = TreeBlockParams;
 
@@ -9,16 +10,22 @@ const TreeBlock = (params: TreeBlockProps) => {
   console.log(branches);
   return (
     <div
-      className="h-[300px] w-[300px]"
+      className="h-[700px] w-[700px]"
       style={{ backgroundColor: params.backgroundColor }}
     >
       {/*debug: just display all the param values*/}
-      {Object.entries(params).map(([key, value]) => (
+      {/* {Object.entries(params).map(([key, value]) => (
         <div key={key}>
           {key}: {value}
         </div>
       ))}
-      Tree Size: {branches.length}
+      Tree Size: {branches.length} */}
+      <Konvas
+        branches={branches}
+        width={700}
+        height={700}
+        backgroundColor={params.backgroundColor}
+      />
     </div>
   );
 };

--- a/src/components/ArtBlock/Tree/TreeBlock.tsx
+++ b/src/components/ArtBlock/Tree/TreeBlock.tsx
@@ -6,8 +6,7 @@ import Konvas from "./Konvas";
 type TreeBlockProps = TreeBlockParams;
 
 const TreeBlock = (params: TreeBlockProps) => {
-  const branches = generateTree(params);
-  console.log(branches);
+  const { branches, boundaries } = generateTree(params);
   return (
     <div
       className="h-[700px] w-[700px]"
@@ -22,6 +21,7 @@ const TreeBlock = (params: TreeBlockProps) => {
       Tree Size: {branches.length} */}
       <Konvas
         branches={branches}
+        boundaries={boundaries}
         width={700}
         height={700}
         backgroundColor={params.backgroundColor}

--- a/src/components/ArtBlock/Tree/generate.ts
+++ b/src/components/ArtBlock/Tree/generate.ts
@@ -69,7 +69,7 @@ const makeBranch = (branchParams: makeBranchArgs) => {
 
   const branchEnd = {
     x: branchOrigin.x + branchLength * Math.sin((branchAngle * Math.PI) / 180),
-    y: branchOrigin.y + branchLength * Math.cos((branchAngle * Math.PI) / 180)
+    y: branchOrigin.y - branchLength * Math.cos((branchAngle * Math.PI) / 180)
   };
   //right and left branches differ only in whether we add or subtract the split angle
   const branchAngleOffsets = [

--- a/src/components/ArtBlock/Tree/generate.ts
+++ b/src/components/ArtBlock/Tree/generate.ts
@@ -1,6 +1,6 @@
 import { TreeBlockParams } from "@/services/ArtBlock.types";
 
-interface Branch {
+export interface Branch {
   origin: Point;
   length: number;
   angle: number;

--- a/src/components/ArtBlock/Tree/generate.ts
+++ b/src/components/ArtBlock/Tree/generate.ts
@@ -8,7 +8,7 @@ export interface Branch {
   endWidth: number;
   color: string;
 }
-interface Point {
+export interface Point {
   x: number;
   y: number;
 }
@@ -17,6 +17,10 @@ interface Point {
 //to be passed down the makeBranch recursion
 interface TreeInfo extends TreeBlockParams {
   branches: Branch[];
+  boundaries: {
+    topLeft: Point;
+    bottomRight: Point;
+  };
 }
 
 /**Takes in the params of a Tree block, returns an array of Branches to render */
@@ -24,7 +28,11 @@ export default function generateTree(params: TreeBlockParams) {
   //make a series of branches based on the params
   //this will be an array of Branch type objects that contain all the information needed to render the tree to the canvas agnostic of render framework
   const branches: Branch[] = [];
-  const treeInfo: TreeInfo = { ...params, branches: branches };
+  const treeInfo: TreeInfo = {
+    ...params,
+    branches: branches,
+    boundaries: { topLeft: { x: 0, y: 0 }, bottomRight: { x: 0, y: 0 } }
+  };
   const rootArgs = {
     treeInfo: treeInfo,
     branchOrigin: { x: 0, y: 0 },
@@ -34,7 +42,7 @@ export default function generateTree(params: TreeBlockParams) {
     branchColor: params.treeColor
   };
   makeBranch(rootArgs);
-  return branches;
+  return { branches, boundaries: treeInfo.boundaries };
 }
 interface makeBranchArgs {
   treeInfo: TreeInfo;
@@ -71,6 +79,23 @@ const makeBranch = (branchParams: makeBranchArgs) => {
     x: branchOrigin.x + branchLength * Math.sin((branchAngle * Math.PI) / 180),
     y: branchOrigin.y - branchLength * Math.cos((branchAngle * Math.PI) / 180)
   };
+  //update the tree's boundaries
+  treeInfo.boundaries.topLeft.x = Math.min(
+    treeInfo.boundaries.topLeft.x,
+    branchEnd.x
+  );
+  treeInfo.boundaries.topLeft.y = Math.min(
+    treeInfo.boundaries.topLeft.y,
+    branchEnd.y
+  );
+  treeInfo.boundaries.bottomRight.x = Math.max(
+    treeInfo.boundaries.bottomRight.x,
+    branchEnd.x
+  );
+  treeInfo.boundaries.bottomRight.y = Math.max(
+    treeInfo.boundaries.bottomRight.y,
+    branchEnd.y
+  );
   //right and left branches differ only in whether we add or subtract the split angle
   const branchAngleOffsets = [
     branchAngle + treeInfo.tilt + treeInfo.splitAngle,

--- a/src/services/ArtBlock.types.ts
+++ b/src/services/ArtBlock.types.ts
@@ -46,7 +46,7 @@ export function defaultArtBlockParams(
         splitAngle: 30,
         tilt: 0,
         minBranchLength: 8,
-        treeColor: "#FFFFFF",
+        treeColor: "#000000",
         backgroundColor: "#d1d1d1",
         colorStyle: "solid",
         gradientColor: null


### PR DESCRIPTION
Refines the BinaryTree art render to scale the tree to fit symetrically within the canvas

-could use some tweaks to parameters that have unexpected effects since things scale now;
-scaling could be made optional
-"min branch size" should be changed to recursion depth straight up
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bdca15e8ebac34b8b28f8531e2341b1fe04357fb  | 
|--------|--------|

### Summary:
Refined BinaryTree art render to scale symmetrically within the canvas and set API routes to 'dynamic' mode.

**Key points**:
- Refined BinaryTree art render to scale symmetrically within the canvas using `react-konva`.
- Added `konva` and `react-konva` dependencies in `package.json`.
- Updated `src/components/ArtBlock/Color/ColorBlock.tsx` to change the size of the color block.
- Created `src/components/ArtBlock/Tree/Konvas.tsx` to handle tree rendering using `react-konva`.
- Created `src/components/ArtBlock/Tree/Trapezoid.tsx` to render trapezoid shapes for tree branches.
- Updated `src/components/ArtBlock/Tree/TreeBlock.tsx` to use the new `Konvas` component for rendering trees.
- Modified `src/components/ArtBlock/Tree/generate.ts` to include tree boundary calculations and return them.
- Updated `src/services/ArtBlock.types.ts` to change the default tree color and include boundary calculations.
- Set `mode` to `dynamic` in `src/app/api/feed/route.ts` and `src/app/api/userAuthCallback/route.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->