### PR TITLE
protects /create route forcing sign in before creating a post

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,12 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
 let reqRecord = {};
 
+const isProtectedRoute = createRouteMatcher(["/create(.*)"]);
 // This Middleware does not protect any routes by default.
 // See https://clerk.com/docs/references/nextjs/clerk-middleware for more information about configuring your Middleware
 export default clerkMiddleware((auth, req) => {
-  // console.log("Middling the wares", req.url);
-  // reqRecord[req.url] = req.nextUrl.pathname;
-  // console.log(reqRecord);
+  if (isProtectedRoute(req)) auth().protect();
 });
 
 export const config = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4bd120230613089e3cf2a96a11b385c9b58ae49f  | 
|--------|--------|

### Summary:
Protects the `/create` route by requiring user sign-in using middleware in `src/middleware.ts`.

**Key points**:
- Protects `/create` route by requiring user sign-in.
- Uses `createRouteMatcher` to identify protected routes.
- Updates `src/middleware.ts` to include the new route protection logic.
- Middleware checks if the request matches `/create` and calls `auth().protect()` if it does.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->