### PR TITLE
Download

### DIFF
--- a/src/app/hooks/useTap.tsx
+++ b/src/app/hooks/useTap.tsx
@@ -3,6 +3,18 @@ import { useRef } from "react";
  * Returns {handleTouchMove, handleTouchEnd}; handleTouchMove should be attached to the
  * onTouchMove event of the element to track drags, and handleTouchEnd should be
  * attached to onTouchEnd and given the callback to run in the event of a non-drag tap
+ *
+ * example:
+ *
+ * const { handleTouchMove, handleTouchEnd } = useTap();
+ * const tapCallback = () => console.log("tapped");
+ * <div
+ *   onTouchMove={handleTouchMove}
+ *   onTouchEnd={handleTouchEnd(tapCallback)}
+ * >
+ *   This div will log "tapped" only when tapped and not dragged
+ *
+ * </div>
  */
 const useTap = () => {
   const draggingRef = useRef(false);

--- a/src/components/ArtBlock.tsx
+++ b/src/components/ArtBlock.tsx
@@ -18,6 +18,7 @@ export interface ArtBlockProps {
   size?: SupportedDisplayParams["size"];
   onTap?: (e?: React.TouchEvent<HTMLDivElement>) => void;
   onClick?: (e?: React.MouseEvent<HTMLDivElement>) => void;
+  downloadSetter?: (obj: { callback: () => void }) => void;
 }
 
 // union of types and params for the supported art blocks
@@ -44,7 +45,11 @@ export default function ArtBlock(props: ArtBlockProps) {
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd(props.onTap)}
         >
-          <tree.Display artParams={props.artParams} size={props.size || 350} />
+          <tree.Display
+            artParams={props.artParams}
+            size={props.size || 350}
+            downloadSetter={props.downloadSetter}
+          />
         </div>
       );
     default:

--- a/src/components/ArtBlock/Block.types.ts
+++ b/src/components/ArtBlock/Block.types.ts
@@ -5,6 +5,7 @@ type ControlProps<AT, S> = {
 type DisplayProps<AT, S> = {
   artParams: { artType: AT } & S;
   size?: number;
+  downloadSetter?: (obj: { callback: () => void }) => void;
 };
 
 export type BlockInterface<AT, SpecificArtBlockProps> = {

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -1,4 +1,4 @@
-import { Stage, Layer, Rect } from "react-konva";
+import { Stage, Layer, Rect, Group } from "react-konva";
 import { Trapezoid } from "./Trapezoid";
 import { Branch, Point } from "./generate";
 
@@ -42,13 +42,7 @@ const Konvas = (props: KonvasProps) => {
     0.9 * Math.min(width / treeTotalDims.width, height / treeTotalDims.height); //scale factor to fit the tree in the canvas
   return (
     <Stage width={width} height={height}>
-      <Layer
-        scale={{ x: canvasFitScaleFactor, y: canvasFitScaleFactor }}
-        offset={{
-          x: -width / 2 / canvasFitScaleFactor + xMidpoint,
-          y: -height / canvasFitScaleFactor + 1.1 * bottomYPositiveSpace
-        }}
-      >
+      <Layer>
         {/* background */}
         <Rect
           x={0}
@@ -57,22 +51,30 @@ const Konvas = (props: KonvasProps) => {
           height={height}
           fill={backgroundColor}
         />
-        {/* tree branches */}
-        {branches.map((branch, idx) => (
-          <Trapezoid
-            key={`branches${idx}`}
-            x={branch.origin.x}
-            y={branch.origin.y}
-            startWidth={branch.startWidth}
-            endWidth={branch.endWidth}
-            length={branch.length}
-            fill={branch.color}
-            stroke={branch.color}
-            strokeWidth={0}
-            rotation={180 + branch.angle}
-            roundEnds={true}
-          />
-        ))}
+        <Group
+          scale={{ x: canvasFitScaleFactor, y: canvasFitScaleFactor }}
+          offset={{
+            x: -width / 2 / canvasFitScaleFactor + xMidpoint,
+            y: -height / canvasFitScaleFactor + 1.1 * bottomYPositiveSpace
+          }}
+        >
+          {/* tree branches */}
+          {branches.map((branch, idx) => (
+            <Trapezoid
+              key={`branches${idx}`}
+              x={branch.origin.x}
+              y={branch.origin.y}
+              startWidth={branch.startWidth}
+              endWidth={branch.endWidth}
+              length={branch.length}
+              fill={branch.color}
+              stroke={branch.color}
+              strokeWidth={0}
+              rotation={180 + branch.angle}
+              roundEnds={true}
+            />
+          ))}
+        </Group>
       </Layer>
     </Stage>
   );

--- a/src/components/ArtBlock/Tree/Konvas.tsx
+++ b/src/components/ArtBlock/Tree/Konvas.tsx
@@ -1,6 +1,7 @@
 import { Stage, Layer, Rect, Group } from "react-konva";
 import { Trapezoid } from "./Trapezoid";
 import { Branch, Point } from "./generate";
+import Konva from "konva";
 
 /**
    interface TrapezoidProps {
@@ -25,6 +26,7 @@ interface KonvasProps {
     topLeft: Point;
     bottomRight: Point;
   };
+  canvasRef: React.RefObject<Konva.Stage>;
 }
 const Konvas = (props: KonvasProps) => {
   const { width, height, backgroundColor, branches, boundaries } = props;
@@ -41,7 +43,7 @@ const Konvas = (props: KonvasProps) => {
   const canvasFitScaleFactor =
     0.9 * Math.min(width / treeTotalDims.width, height / treeTotalDims.height); //scale factor to fit the tree in the canvas
   return (
-    <Stage width={width} height={height}>
+    <Stage width={width} height={height} ref={props.canvasRef}>
       <Layer>
         {/* background */}
         <Rect

--- a/src/components/ArtBlock/Tree/TreeBlock.tsx
+++ b/src/components/ArtBlock/Tree/TreeBlock.tsx
@@ -5,14 +5,21 @@ import Konvas from "./Konvas";
 import { Tree } from ".";
 import Konva from "konva";
 
-const downloadCallback = (canvasRef: React.RefObject<Konva.Stage>) => {
+const downloadCallback = (
+  canvasRef: React.RefObject<Konva.Stage>,
+  downloadSize: number = 1500
+) => {
   return () => {
     if (!canvasRef.current) {
       console.error("canvasRef is null");
     }
     const link = document.createElement("a");
     link.download = "tree.png";
-    link.href = canvasRef.current.toDataURL();
+    const canvas = canvasRef.current;
+    const canvasWidth = canvas.width();
+    link.href = canvasRef.current.toDataURL({
+      pixelRatio: downloadSize / canvasWidth
+    });
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);

--- a/src/components/ArtBlock/Tree/TreeBlock.tsx
+++ b/src/components/ArtBlock/Tree/TreeBlock.tsx
@@ -1,35 +1,51 @@
 import { TreeBlockParams } from "@/services/ArtBlock.types";
-import { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import generateTree from "./generate";
 import Konvas from "./Konvas";
 import { Tree } from ".";
+import Konva from "konva";
+
+const downloadCallback = (canvasRef: React.RefObject<Konva.Stage>) => {
+  return () => {
+    if (!canvasRef.current) {
+      console.error("canvasRef is null");
+    }
+    const link = document.createElement("a");
+    link.download = "tree.png";
+    link.href = canvasRef.current.toDataURL();
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+};
 
 const TreeBlock: Tree["Display"] = params => {
   const { branches, boundaries } = useMemo(
     () => generateTree(params.artParams),
     [params]
   );
+  const canvasRef = useRef<Konva.Stage>(null);
+  useEffect(() => {
+    if (!params.downloadSetter) {
+      console.log(params.downloadSetter);
+      return;
+    }
+    params.downloadSetter({ callback: downloadCallback(canvasRef) });
+  }, [canvasRef.current]);
+
   return (
     <div
       style={{
         backgroundColor: params.artParams.backgroundColor
-        // width: params.size,
-        // height: params.size
       }}
     >
-      {/*debug: just display all the param values*/}
-      {/* {Object.entries(params).map(([key, value]) => (
-        <div key={key}>
-          {key}: {value}
-        </div>
-      ))}
-      Tree Size: {branches.length} */}
       <Konvas
         branches={branches}
         boundaries={boundaries}
         width={params.size}
         height={params.size}
         backgroundColor={params.artParams.backgroundColor}
+        canvasRef={canvasRef}
       />
     </div>
   );

--- a/src/components/ArtBlockModal.tsx
+++ b/src/components/ArtBlockModal.tsx
@@ -33,13 +33,13 @@ const ArtBlockModal = ({ blockData, closeOnClick }: ArtBlockModalProps) => {
           downloadSetter={setDownloadCallback}
         />
         <X
-          className="absolute top-2 right-2 cursor-pointer hover:bg-slate-600 hover:text-slate-200 rounded-full"
+          className="absolute top-2 right-2 cursor-pointer bg-slate-600 text-slate-200 opacity-50 hover:opacity-95 rounded-full"
           size={size / 20}
           onClick={closeOnClick}
         />
         <Download
-          className="absolute bottom-2 right-2 cursor-pointer  hover:text-slate-900"
-          size={size / 20}
+          className="absolute bottom-2 right-2 cursor-pointer bg-slate-600 text-slate-200 opacity-50 hover:opacity-95 p-2 rounded-full"
+          size={5 + size / 20}
           onClick={downloadCallback.callback}
         />
       </div>

--- a/src/components/ArtBlockModal.tsx
+++ b/src/components/ArtBlockModal.tsx
@@ -14,7 +14,9 @@ interface ArtBlockModalProps {
 }
 const ArtBlockModal = ({ blockData, closeOnClick }: ArtBlockModalProps) => {
   const [size, setSize] = useState(() => modalSize());
-
+  const [downloadCallback, setDownloadCallback] = useState({
+    callback: () => {}
+  });
   useEffect(() => {
     const resizeCallback = () => setSize(modalSize());
     window.addEventListener("resize", resizeCallback);
@@ -24,7 +26,12 @@ const ArtBlockModal = ({ blockData, closeOnClick }: ArtBlockModalProps) => {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
       <div className="relative bg-white rounded-lg">
-        <ArtBlock {...blockData} size={size} onTap={closeOnClick} />
+        <ArtBlock
+          {...blockData}
+          size={size}
+          onTap={closeOnClick}
+          downloadSetter={setDownloadCallback}
+        />
         <X
           className="absolute top-2 right-2 cursor-pointer hover:bg-slate-600 hover:text-slate-200 rounded-full"
           size={size / 20}
@@ -33,7 +40,7 @@ const ArtBlockModal = ({ blockData, closeOnClick }: ArtBlockModalProps) => {
         <Download
           className="absolute bottom-2 right-2 cursor-pointer  hover:text-slate-900"
           size={size / 20}
-          // onClick={downloadOnClick}
+          onClick={downloadCallback.callback}
         />
       </div>
     </div>

--- a/src/components/ArtBlockModal.tsx
+++ b/src/components/ArtBlockModal.tsx
@@ -1,5 +1,5 @@
 import { ArtBlockDataLocal } from "@/services/ArtBlock";
-import { X } from "lucide-react";
+import { Download, X } from "lucide-react";
 import ArtBlock from "./ArtBlock";
 import { useEffect, useMemo, useState } from "react";
 
@@ -29,6 +29,11 @@ const ArtBlockModal = ({ blockData, closeOnClick }: ArtBlockModalProps) => {
           className="absolute top-2 right-2 cursor-pointer hover:bg-slate-600 hover:text-slate-200 rounded-full"
           size={size / 20}
           onClick={closeOnClick}
+        />
+        <Download
+          className="absolute bottom-2 right-2 cursor-pointer  hover:text-slate-900"
+          size={size / 20}
+          // onClick={downloadOnClick}
         />
       </div>
     </div>

--- a/src/components/ArtFeed.tsx
+++ b/src/components/ArtFeed.tsx
@@ -156,10 +156,6 @@ const ArtBlockSkeleton = ({ size }: { size: number }) => {
           className="skeleton rounded-xl animate-pulse"
           style={{ width: (150 / 350) * size, height: (30 / 350) * size }}
         ></div>
-        <div
-          className="skeleton rounded-full animate-pulse"
-          style={{ width: (30 / 350) * size, height: (30 / 350) * size }}
-        ></div>
       </div>
     </div>
   );

--- a/src/components/ArtFeedBlock.tsx
+++ b/src/components/ArtFeedBlock.tsx
@@ -19,7 +19,7 @@ function ArtFeedBlock(props: ArtFeedBlockProps) {
           // onTap={() => console.log("tapped")}
         />
         <Fullscreen
-          className="hidden absolute top-2 right-2 cursor-pointer hover:bg-slate-200 hover:bg-opacity-50 rounded-xl p-0.5 group-hover:block"
+          className="hidden absolute top-1 right-1 cursor-pointer bg-slate-600 text-slate-200 opacity-25 hover:opacity-95 rounded-lg p-0.5 group-hover:block"
           size={24}
           onClick={props.onFullscreenClick}
         />

--- a/src/components/ArtFeedBlock.tsx
+++ b/src/components/ArtFeedBlock.tsx
@@ -64,14 +64,6 @@ const PostDetails = (details: PostDetailsProps) => {
           liked={details.liked}
           artId={details.artId}
         />
-        {details.artType === "tree" && (
-          <div
-            className="tooltip tooltip-right"
-            data-tip="Right click canvas to save image"
-          >
-            <Download className="cursor-pointer  w-3 h-3 md:w-4 md:h-4 hover:text-black rounded-sm" />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/ArtFeedBlock.tsx
+++ b/src/components/ArtFeedBlock.tsx
@@ -20,7 +20,7 @@ function ArtFeedBlock(props: ArtFeedBlockProps) {
         />
         <Fullscreen
           className="hidden absolute top-2 right-2 cursor-pointer hover:bg-slate-200 hover:bg-opacity-50 rounded-xl p-0.5 group-hover:block"
-          size={32}
+          size={24}
           onClick={props.onFullscreenClick}
         />
       </div>


### PR DESCRIPTION
Adds download functionality to the zoomed in artmodal; currently defaults to download a 1500x1500 pixel image, but the callback creator can take an argument for size for future modularity
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8cee3c177b29cec9f3ab3856e871608c8630d192  | 
|--------|--------|

### Summary:
Added download functionality to the zoomed-in art modal, allowing users to download a 1500x1500 pixel image by default.

**Key points**:
- Added `downloadSetter` prop to `ArtBlockProps` in `src/components/ArtBlock.tsx`.
- Updated `DisplayProps` in `src/components/ArtBlock/Block.types.ts` to include `downloadSetter`.
- Modified `Konvas` component in `src/components/ArtBlock/Tree/Konvas.tsx` to accept `canvasRef` and use it for downloading.
- Implemented `downloadCallback` in `TreeBlock` in `src/components/ArtBlock/Tree/TreeBlock.tsx`.
- Added download button to `ArtBlockModal` in `src/components/ArtBlockModal.tsx`.
- Adjusted `ArtFeed` and `ArtFeedBlock` components to accommodate new download functionality.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->